### PR TITLE
Remove static method for awarding achievements

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -1085,19 +1085,6 @@ public:
   }
 
   //============================================================================
-  /// @brief Get the achievement URL and ID
-  ///
-  /// @param[in] callback A callback that receives the URL and ID
-  ///
-  /// @return the error, or @ref GAME_ERROR_NO_ERROR if the call was successful
-  ///
-  virtual GAME_ERROR GetCheevo_URL_ID(void (*callback)(const char* achievementUrl,
-                                                       unsigned cheevoId))
-  {
-    return GAME_ERROR_NOT_IMPLEMENTED;
-  }
-
-  //============================================================================
   /// @brief Resets the runtime. Must be called each time a new rom is starting
   ///        and when the savestate is changed
   ///
@@ -1105,6 +1092,12 @@ public:
   ///         successfully
   ///
   virtual GAME_ERROR RCResetRuntime() { return GAME_ERROR_NOT_IMPLEMENTED; }
+
+  void AwardAchievement(const char* achievementUrl, unsigned cheevoId)
+  {
+    m_instanceData->toKodi->AwardAchievement(m_instanceData->toKodi->kodiInstance, achievementUrl,
+                                             cheevoId);
+  }
 
   //----------------------------------------------------------------------------
 
@@ -1154,7 +1147,6 @@ private:
     instance->game->toAddon->RCEnableRichPresence = ADDON_RCEnableRichPresence;
     instance->game->toAddon->RCGetRichPresenceEvaluation = ADDON_RCGetRichPresenceEvaluation;
     instance->game->toAddon->ActivateAchievement = ADDON_ActivateAchievement;
-    instance->game->toAddon->GetCheevo_URL_ID = ADDON_GetCheevo_URL_ID;
     instance->game->toAddon->RCResetRuntime = ADDON_RCResetRuntime;
 
     instance->game->toAddon->FreeString = ADDON_FreeString;
@@ -1472,14 +1464,6 @@ private:
   {
     return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)
         ->ActivateAchievement(cheevoId, memaddr);
-  }
-
-  inline static GAME_ERROR ADDON_GetCheevo_URL_ID(const AddonInstance_Game* instance,
-                                                  void (*callback)(const char* achievementUrl,
-                                                                   unsigned cheevoId))
-  {
-    return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)
-        ->GetCheevo_URL_ID(callback);
   }
 
   inline static GAME_ERROR ADDON_RCResetRuntime(const AddonInstance_Game* instance)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -1151,6 +1151,9 @@ extern "C"
     void (*CloseStream)(KODI_HANDLE, KODI_GAME_STREAM_HANDLE);
     game_proc_address_t (*HwGetProcAddress)(KODI_HANDLE kodiInstance, const char* symbol);
     bool (*InputEvent)(KODI_HANDLE kodiInstance, const struct game_input_event* event);
+    void (*AwardAchievement)(KODI_HANDLE kodiInstance,
+                             const char* achievementUrl,
+                             unsigned cheevoId);
   } AddonToKodiFuncTable_Game;
 
   /*!
@@ -1215,8 +1218,6 @@ extern "C"
     GAME_ERROR(__cdecl* RCGetRichPresenceEvaluation)
     (const AddonInstance_Game*, char**, unsigned int);
     GAME_ERROR(__cdecl* ActivateAchievement)(const AddonInstance_Game*, unsigned int, const char*);
-    GAME_ERROR(__cdecl* GetCheevo_URL_ID)
-    (const AddonInstance_Game*, void (*)(const char*, unsigned int));
     GAME_ERROR(__cdecl* RCResetRuntime)(const AddonInstance_Game*);
     void(__cdecl* FreeString)(const AddonInstance_Game*, char*);
   } KodiToAddonFuncTable_Game;

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.h
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.h
@@ -34,11 +34,8 @@ public:
   void EnableRichPresence();
   std::string GetRichPresenceEvaluation();
 
-  void ActivateAchievement();
-  static void Callback_URL_ID(const char* achievementUrl, unsigned int cheevoId);
-  void CheckTriggeredAchievement();
-
-  static std::unordered_map<unsigned, std::vector<std::string>> m_activatedCheevoMap;
+  void ActivateAchievements();
+  void AwardAchievement(const char* achievementUrl, unsigned cheevoId);
 
 private:
   bool LoadData();
@@ -52,6 +49,8 @@ private:
   uint32_t m_gameID{};
   RConsoleID m_consoleID = RConsoleID::RC_INVALID_ID;
   bool m_richPresenceLoaded{};
+
+  std::unordered_map<unsigned, std::vector<std::string>> m_activatedCheevoMap;
 
   const std::map<std::string, RConsoleID> m_extensionToConsole = {
       {".a26", RConsoleID::RC_CONSOLE_ATARI_2600},

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -19,6 +19,7 @@
 #include "addons/BinaryAddonCache.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
+#include "cores/RetroPlayer/cheevos/Cheevos.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "games/GameServices.h"
@@ -173,6 +174,7 @@ bool CGameClient::Initialize(void)
   m_ifc.game->toKodi->CloseStream = cb_close_stream;
   m_ifc.game->toKodi->HwGetProcAddress = cb_hw_get_proc_address;
   m_ifc.game->toKodi->InputEvent = cb_input_event;
+  m_ifc.game->toKodi->AwardAchievement = cb_award_achievement;
 
   memset(m_ifc.game->toAddon, 0, sizeof(KodiToAddonFuncTable_Game));
 
@@ -693,4 +695,17 @@ bool CGameClient::cb_input_event(KODI_HANDLE kodiInstance, const game_input_even
     return false;
 
   return gameClient->Input().ReceiveInputEvent(*event);
+}
+
+void CGameClient::cb_award_achievement(KODI_HANDLE kodiInstance,
+                                       const char* achievementUrl,
+                                       unsigned cheevoId)
+{
+  CGameClient* gameClient = static_cast<CGameClient*>(kodiInstance);
+  if (!gameClient || !gameClient->m_cheevos)
+  {
+    return;
+  }
+
+  gameClient->m_cheevos->AwardAchievement(achievementUrl, cheevoId);
 }

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -25,6 +25,7 @@ namespace KODI
 {
 namespace RETRO
 {
+class CCheevos;
 class IStreamManager;
 }
 
@@ -210,6 +211,9 @@ private:
   static void cb_close_stream(KODI_HANDLE kodiInstance, KODI_GAME_STREAM_HANDLE stream);
   static game_proc_address_t cb_hw_get_proc_address(KODI_HANDLE kodiInstance, const char* sym);
   static bool cb_input_event(KODI_HANDLE kodiInstance, const game_input_event* event);
+  static void cb_award_achievement(KODI_HANDLE kodiInstance,
+                                   const char* achievementUrl,
+                                   unsigned cheevoId); 
   //@}
 
   // Game subsystems
@@ -236,6 +240,8 @@ private:
   std::unique_ptr<CGameClientInGameSaves> m_inGameSaves;
 
   CCriticalSection m_critSection;
+
+  RETRO::CCheevos* m_cheevos;
 };
 
 } // namespace GAME


### PR DESCRIPTION
## Description
This PR moves a static method to award achievements from RetroPlayer to game.libretro.
This commit should be merged and squashed onto f3832aeec5e814d9c9b2353991b2950b3924be22 before merging https://github.com/garbear/xbmc/pull/127

Relevant changes to game.libretro https://github.com/Shardul555/game.libretro/pull/1